### PR TITLE
do not handle MPI_IN_PLACE in Fortran with Open MPI higher than 1.6

### DIFF
--- a/etc/wrap_mpi_f.c
+++ b/etc/wrap_mpi_f.c
@@ -33,7 +33,7 @@ FRET FFNAME(FPARAMS)
   extern void* MPIR_F_MPI_IN_PLACE;
   if (sbuf == MPIR_F_MPI_IN_PLACE) sbuf = MPI_IN_PLACE;
 #endif
-#ifdef OPEN_MPI
+#if defined(OPEN_MPI) && OMPI_MAJOR_VERSION == 1 && OMPI_MINOR_VERSION <= 6
 #include "openmpi/opal_config.h"
 #include "openmpi/ompi/mpi/f77/constants.h"
   sbuf = (char *) OMPI_F2C_IN_PLACE(sbuf);


### PR DESCRIPTION
OMPI_F2C_IN_PLACE macro is only available until Open MPI 1.6,
so do MPI_IN_PLACE cannot be handled in Fortran.
this fixes nerscadmin/IPM@8f628dadc502b3e0113d6ab3075bf66b107f07e5
with Open MPI > 1.6