### PR TITLE
revamp C and Fortran wrappers :

### DIFF
--- a/bin/make_wrappers
+++ b/bin/make_wrappers
@@ -611,12 +611,12 @@ EOF
 	    foreach $_ (@template_f)
 	    {
 		$line = $_;
-		$line=~s/CFNAME/$1$c->{cfn}/;
-		$line=~s/FFNAME/$c->{ffn}/;
-		$line=~s/FRET/$c->{frv}/;
-		$line=~s/FPARAMS/$c->{fai}/;
-		$line=~s/FARGS/$c->{far}/;
-		$line=~s/F2CARGS/$c->{f2c}/;
+		$line=~s/__CFNAME__/$1$c->{cfn}/;
+		$line=~s/__FFNAME__/$c->{ffn}/;
+		$line=~s/__FRET__/$c->{frv}/;
+		$line=~s/__FPARAMS__/$c->{fai}/;
+		$line=~s/__FARGS__/$c->{far}/;
+		$line=~s/__F2CARGS__/$c->{f2c}/;
 		$line=~s/HAVE_CREQ/$have_creq/;
 		$line=~s/HAVE_CSTAT/$have_cstat/;
 		$line=~s/HAVE_COLLECTIVE/$have_collective/;

--- a/etc/wrap_mpi_c.c
+++ b/etc/wrap_mpi_c.c
@@ -46,21 +46,12 @@
  * GET_RANK   __GET_RANK__
  */
 
-__CRET__ __CFNAME__(__CPARAMS__)
+static void IPM___CFNAME__(__CPARAMS__, double tstart, double tstop)
 {
-  __CRET__ rv;
   int bytes, irank;
+  double t;
   int csite, idx, idx2, regid; 
-  double tstart, tstop, t;
   IPM_KEY_TYPE key;
-
-  IPM_TIMESTAMP(tstart);
-  rv = __PCFNAME__(__CARGS__);
-  IPM_TIMESTAMP(tstop);
-
-  if( ipm_state!=STATE_ACTIVE ) {
-    return rv;
-  }
 
   t=tstop-tstart;
   
@@ -157,8 +148,26 @@ __CRET__ __CFNAME__(__CPARAMS__)
 #ifdef HAVE_SNAP
  IPM_SNAP;
 #endif
+}
+
+__CRET__ __CFNAME__(__CPARAMS__)
+{
+  __CRET__ rv;
+  double tstart, tstop;
+
+  IPM_TIMESTAMP(tstart);
+  rv = __PCFNAME__(__CARGS__);
+  IPM_TIMESTAMP(tstop);
+
+  if( ipm_state!=STATE_ACTIVE ) {
+    return rv;
+  }
+
+  IPM___CFNAME__(__CARGS__, tstart, tstop);
  
   return rv;
 }
+
+
 
 

--- a/etc/wrap_mpi_f.c
+++ b/etc/wrap_mpi_f.c
@@ -1,12 +1,14 @@
 
-/* ---- wrapping FFNAME ---- */
+/* ---- wrapping __FFNAME__ ---- */
  
 /*
  *
  */
 
-FRET FFNAME(FPARAMS)
+__FRET__ __FFNAME__(__FPARAMS__)
 {
+  double tstart, tstop;
+
 #if HAVE_CREQ    /* HAVE _CREQ */ 
   MPI_Request creq; 
 #endif
@@ -28,19 +30,13 @@ FRET FFNAME(FPARAMS)
   MPI_Group cgroup_out;
 #endif
 
-#if HAVE_COLLECTIVE   /* HAVE _COLLECTIVE */
-#ifdef MPICH2
-  extern void* MPIR_F_MPI_IN_PLACE;
-  if (sbuf == MPIR_F_MPI_IN_PLACE) sbuf = MPI_IN_PLACE;
-#endif
-#ifdef OPEN_MPI
-#include "openmpi/opal_config.h"
-#include "openmpi/ompi/mpi/f77/constants.h"
-  sbuf = (char *) OMPI_F2C_IN_PLACE(sbuf);
-#endif
-#endif
+  IPM_TIMESTAMP(tstart);
+  p__FFNAME__(__FARGS__);
+  IPM_TIMESTAMP(tstop);
 
-  *info=CFNAME(F2CARGS);
+  if( ipm_state!=STATE_ACTIVE ) {
+    return;
+  }
   
 #if HAVE_CSTAT   /* HAVE_CSTAT */ 
   if (*info==MPI_SUCCESS) 
@@ -66,6 +62,7 @@ FRET FFNAME(FPARAMS)
   if( *info==MPI_SUCCESS )
     *group_out=MPI_Group_c2f(cgroup_out);
 #endif
+  IPM___CFNAME__(__F2CARGS__, tstart, tstop);
 
 }
 


### PR DESCRIPTION
 - C wrapper is split into the C wrapper itself and the IPM related stuff
 - Fortran wrapper now calls the PMPI_ Fortran subroutine and the C IPM related stuff

here is an example with MPI_Send:

void IPM_MPI_Send(MPI3CONST void *sbuf, int scount, MPI_Datatype stype, int dest, int tag, MPI_Comm comm_in, double tstart, double tstop)
{
    // do IPM related stuff
}

int MPI_Send(MPI3CONST void *sbuf, int scount, MPI_Datatype stype, int dest, int tag, MPI_Comm comm_in)
{
  int rv;
  double tstart, tstop;

  IPM_TIMESTAMP(tstart);
  rv = PMPI_Send(sbuf,scount,stype,dest,tag,comm_in);
  IPM_TIMESTAMP(tstop);

  if( ipm_state!=STATE_ACTIVE ) {
    return rv;
  }

  IPM_MPI_Send(sbuf,scount,stype,dest,tag,comm_in, tstart, tstop);

  return rv;
}

void mpi_send_(void *sbuf, MPI_Fint *scount, MPI_Fint *stype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm_in, MPI_Fint *info)
{
 double tstart, tstop;

  // f2c conversions
  IPM_TIMESTAMP(tstart);
  pmpi_send_(sbuf,scount,stype,dest,tag,comm_in,info);
  IPM_TIMESTAMP(tstop);

  if( ipm_state!=STATE_ACTIVE ) {
    return;
  }

  // f2c conversions
  IPM_MPI_Send(sbuf,*scount,MPI_Type_f2c(*stype),*dest,*tag,MPI_Comm_f2c(*comm_in), tstart, tstop);

}