### PR TITLE
PMON Robust Configure Changes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -196,6 +196,17 @@ AC_ARG_WITH(papi,
     ]
 )
 
+AC_ARG_ENABLE(pmon,
+  AC_HELP_STRING([--enable-pmon], [Enables power monitoring module (default=no)]),
+    [
+	    enable_mod_pmon=yes
+    ],
+    [
+		enable_mod_pmon=no
+    ]
+)
+
+
 
 report_libunwind=no
 AC_ARG_WITH(libunwind,

--- a/configure.ac
+++ b/configure.ac
@@ -64,7 +64,7 @@ AC_PROG_LIBTOOL
 
 # defining the enabled modules
 enable_mod_mpi=yes
-enable_mod_pmon=yes
+enable_mod_pmon=no
 enable_mod_posixio=no
 enable_mod_mpiio=no
 enable_mod_self_monitor=no
@@ -178,7 +178,7 @@ AC_ARG_WITH(papi,
     [
    	if test -d "$withval"; then
 	   		CFLAGS="$CFLAGS -I$withval/include"
-			LDFLAGS="$LDFLAGS -L$withval/lib" # -Wl,-rpath=$withval/lib"
+			LDFLAGS="$LDFLAGS -L$withval/lib" "-Wl,-rpath=$withval/lib"
 			LIBS="$LIBS -lpapi"
 			echo "papi: $withval"
 			enable_mod_papi=yes

--- a/configure.ac
+++ b/configure.ac
@@ -178,7 +178,7 @@ AC_ARG_WITH(papi,
     [
    	if test -d "$withval"; then
 	   		CFLAGS="$CFLAGS -I$withval/include"
-			LDFLAGS="$LDFLAGS -L$withval/lib" "-Wl,-rpath=$withval/lib"
+			LDFLAGS="$LDFLAGS -L$withval/lib -Wl,-rpath=$withval/lib"
 			LIBS="$LIBS -lpapi"
 			echo "papi: $withval"
 			enable_mod_papi=yes

--- a/include/ipm_core.h
+++ b/include/ipm_core.h
@@ -38,6 +38,7 @@
 
 /* report nested regions? */
 #define FLAG_NESTED_REGIONS       (0x0000000000000001ULL <<  12)
+#define FLAG_PMON                 (0x0000000000000001ULL <<  13)
 
 
 /* clear all REPORT bits */

--- a/src/ipm_core.c
+++ b/src/ipm_core.c
@@ -208,7 +208,8 @@ int ipm_init(int flags)
 #endif
 
 #ifdef HAVE_PMON
-  modules[IPM_MODULE_PMON].init=mod_pmon_init;
+  if (task.flags & FLAG_PMON)
+    modules[IPM_MODULE_PMON].init=mod_pmon_init;
 #endif
 
 

--- a/src/ipm_env.c
+++ b/src/ipm_env.c
@@ -25,6 +25,9 @@ extern char **environ;
 #define ENV_SNAP           8
 #endif
 #define ENV_NESTED_REGIONS 9
+#ifdef HAVE_PMON
+#define ENV_PMON 10
+#endif
 
 
 #define MAXSIZE_ENVKEY  120
@@ -125,6 +128,12 @@ int ipm_get_env()
 #ifdef HAVE_SNAP
     else if(!strcmp("IPM_SNAP", key)) {
       ipm_check_env(ENV_SNAP, val);
+    }
+#endif
+
+#ifdef HAVE_PMON
+    else if(!strcmp("IPM_PMON", key)) {
+        ipm_check_env(ENV_PMON, val);
     }
 #endif
 
@@ -262,6 +271,12 @@ int ipm_check_env(int env, char *val)
     case ENV_SNAP: 
       task.snap_period = atof(val);
      break;
+#endif
+    
+#ifdef HAVE_PMON
+    case ENV_PMON:
+        task.flags |= FLAG_PMON;
+    break;
 #endif
 
     case ENV_NESTED_REGIONS:

--- a/src/report.c
+++ b/src/report.c
@@ -480,7 +480,10 @@ void ipm_banner(FILE *f)
   banner.flags|=BANNER_HAVE_CUFFT;
 #endif
 #ifdef HAVE_PMON
-  banner.flags|=BANNER_HAVE_ENERGY;
+  if (task.flags & FLAG_PMON)
+  {
+    banner.flags|=BANNER_HAVE_ENERGY;
+  }
 #endif
 
   if( task.flags&FLAG_REPORT_FULL )

--- a/src/report_banner.c
+++ b/src/report_banner.c
@@ -241,6 +241,7 @@ void ipm_print_region(FILE *f, banner_t *data, regstats_t *reg)
 	  data->procmem.dsum, data->procmem.dsum/(double)ntasks,
 	  data->procmem.dmin, data->procmem.dmax);
 
+  #ifdef HAVE_PMON
   if( data->flags&BANNER_HAVE_ENERGY ) {
     double joules =  reg->energy.dsum;
     double cpu_joules =  reg->cpu_energy.dsum;
@@ -274,6 +275,7 @@ void ipm_print_region(FILE *f, banner_t *data, regstats_t *reg)
     fprintf(f, "#    -mem   :    %10lf   %10lf  %10lf   %10lf \n", mem_kwh, mem_kwh/ntasks, reg->mem_energy.dmin/3600000.0, reg->mem_energy.dmax/3600000.0);
     fprintf(f, "#    -other :    %10lf   %10lf  %10lf   %10lf \n", other_kwh, other_kwh/ntasks, reg->other_energy.dmin/3600000.0, reg->other_energy.dmax/3600000.0);
   }
+#endif
 
   if( data->flags&BANNER_FULL ) 
     {

--- a/src/report_xml.c
+++ b/src/report_xml.c
@@ -425,6 +425,8 @@ int xml_hpm(void *ptr, taskdata_t *t, region_t *reg) {
   res += ipm_printf(ptr, "</hpm>\n");
 #endif /* HAVE_PAPI */
 #ifdef HAVE_PMON
+    if (task.flags & FLAG_PMON)
+    {
     res += ipm_printf(ptr,
 "<pmon\n\
 <device name=\"node\" avg_power=\"%lf\" energy=\"%lf\">\n\
@@ -436,6 +438,7 @@ int xml_hpm(void *ptr, taskdata_t *t, region_t *reg) {
           reg->cpu_energy/reg->wtime, reg->cpu_energy,
           reg->mem_energy/reg->wtime, reg->mem_energy,
           reg->other_energy/reg->wtime, reg->other_energy);
+    }
 #endif
   return res;
 }

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -21,6 +21,7 @@ SUBDIRS = test.allgather \
 		  test.simple_mpi \
 		  test.status_ignore
 
+LDFLAGS:=
 
 dnl	  test.pomp-standalone  (sahu: disabled for now)
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -21,7 +21,7 @@ SUBDIRS = test.allgather \
 		  test.simple_mpi \
 		  test.status_ignore
 
-LDFLAGS:=
+LDFLAGS=
 
 dnl	  test.pomp-standalone  (sahu: disabled for now)
 

--- a/test/test.allgather/Makefile.am
+++ b/test/test.allgather/Makefile.am
@@ -1,5 +1,5 @@
 
-INCLUDES = -I$(top_srcdir)/include
+AM_CPPFLAGS = -I$(top_srcdir)/include
 
 bin_PROGRAMS = allgather allgather.ipm
 

--- a/test/test.allgatherv/Makefile.am
+++ b/test/test.allgatherv/Makefile.am
@@ -1,5 +1,5 @@
 
-INCLUDES = -I$(top_srcdir)/include
+AM_CPPFLAGS = -I$(top_srcdir)/include
 
 bin_PROGRAMS = allgatherv allgatherv.ipm
 

--- a/test/test.allreduce/Makefile.am
+++ b/test/test.allreduce/Makefile.am
@@ -1,5 +1,5 @@
 
-INCLUDES = -I$(top_srcdir)/include
+AM_CPPFLAGS = -I$(top_srcdir)/include
 
 bin_PROGRAMS = allreduce allreduce.ipm
 

--- a/test/test.alltoall/Makefile.am
+++ b/test/test.alltoall/Makefile.am
@@ -1,5 +1,5 @@
 
-INCLUDES = -I$(top_srcdir)/include
+AM_CPPFLAGS = -I$(top_srcdir)/include
 
 bin_PROGRAMS = alltoall alltoall.ipm
 

--- a/test/test.alltoallv/Makefile.am
+++ b/test/test.alltoallv/Makefile.am
@@ -1,5 +1,5 @@
 
-INCLUDES = -I$(top_srcdir)/include
+AM_CPPFLAGS = -I$(top_srcdir)/include
 
 bin_PROGRAMS = alltoallv alltoallv.ipm
 

--- a/test/test.bcast/Makefile.am
+++ b/test/test.bcast/Makefile.am
@@ -1,5 +1,5 @@
 
-INCLUDES = -I$(top_srcdir)/include
+AM_CPPFLAGS = -I$(top_srcdir)/include
 
 bin_PROGRAMS = bcast bcast.ipm
 

--- a/test/test.gather/Makefile.am
+++ b/test/test.gather/Makefile.am
@@ -1,5 +1,5 @@
 
-INCLUDES = -I$(top_srcdir)/include
+AM_CPPFLAGS = -I$(top_srcdir)/include
 
 bin_PROGRAMS = gather gather.ipm
 

--- a/test/test.gatherv/Makefile.am
+++ b/test/test.gatherv/Makefile.am
@@ -1,5 +1,5 @@
 
-INCLUDES = -I$(top_srcdir)/include
+AM_CPPFLAGS = -I$(top_srcdir)/include
 
 bin_PROGRAMS = gatherv gatherv.ipm
 

--- a/test/test.hello/Makefile.am
+++ b/test/test.hello/Makefile.am
@@ -1,4 +1,6 @@
 
+AM_CPPFLAGS = -I$(top_srcdir)/include
+
 bin_PROGRAMS = hello hello.ipm
 
 HELLO_SOURCES = main.c

--- a/test/test.pmon/Makefile.am
+++ b/test/test.pmon/Makefile.am
@@ -4,7 +4,7 @@ bin_PROGRAMS = pmon pmon.ipm
 PMON_SOURCES = pmon.c
 
 CC = $(MPICC)
-CFLAGS+=  -Wall -Wextra
+AM_CFLAGS=  -Wall -Wextra
 pmon_ipm_SOURCES = $(PMON_SOURCES)
 
 pmon_ipm_LDADD   = -L$(top_builddir)/src/.libs/ -lipm

--- a/test/test.pmon/README
+++ b/test/test.pmon/README
@@ -1,3 +1,5 @@
+Set IPM_PMON=1 for pmon to work at runtime.
+
 short test demonstrating power management over sleeps. Sleeps are 5, 10, 15 
 seconds. the most deeply-nested regions should have energy scaled to the length
 of the sleep. Outer regions should be the sum of the inner regions. Power consumption

--- a/test/test.posixio-helloworld/Makefile.am
+++ b/test/test.posixio-helloworld/Makefile.am
@@ -1,4 +1,5 @@
 
+CC = $(MPICC)
 
 
 bin_PROGRAMS = posixio-helloworld posixio-helloworld.ipm

--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -2,7 +2,7 @@
 
 if ENABLE_PARSER
 
-INCLUDES = -I../include -I./cubew/lib
+AM_CPPFLAGS = -I../include -I./cubew/lib
 
 bin_PROGRAMS = ipm_parse
 


### PR DESCRIPTION
Added robust configure and runtime enabling options for the power monitoring module. Corrected some variable usage in the tests directory that caused autoconf issues. Corrected rpath issue so that rpath is enabled for src but not for test, fixing the vanilla test build. Minor typo fixes and usage information for pmon.