### PR TITLE
Papi Multiplexing and Refactor

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -196,6 +196,13 @@ AC_ARG_WITH(papi,
     ]
 )
 
+AC_ARG_ENABLE(papi-multiplexing,
+    AC_HELP_STRING([--enable-papi-multiplexing], [If PAPI is enabled, allows for multiplexing.]),
+    [CFLAGS="$CFLAGS -DUSE_PAPI_MULTIPLEXING"],
+    []
+)
+
+
 AC_ARG_ENABLE(pmon,
   AC_HELP_STRING([--enable-pmon], [Enables power monitoring module (default=no)]),
     [

--- a/include/ipm_sizes.h
+++ b/include/ipm_sizes.h
@@ -50,8 +50,8 @@
 
 // Consider updating MAXSIZE_ENVKEY if you change these values...
 /* module papi */
-#define MAXNUM_PAPI_EVENTS      32
-#define MAXNUM_PAPI_COUNTERS    16
+#define MAXNUM_PAPI_EVENTS      128
+#define MAXNUM_PAPI_COUNTERS    128
 #define MAXNUM_PAPI_COMPONENTS  1
 #define MAXSIZE_PAPI_EVTNAME    32
 

--- a/include/ipm_sizes.h
+++ b/include/ipm_sizes.h
@@ -50,8 +50,8 @@
 
 // Consider updating MAXSIZE_ENVKEY if you change these values...
 /* module papi */
-#define MAXNUM_PAPI_EVENTS      128
-#define MAXNUM_PAPI_COUNTERS    128
+#define MAXNUM_PAPI_EVENTS      1024
+#define MAXNUM_PAPI_COUNTERS    1024
 #define MAXNUM_PAPI_COMPONENTS  1
 #define MAXSIZE_PAPI_EVTNAME    32
 

--- a/include/ipm_sizes.h
+++ b/include/ipm_sizes.h
@@ -50,13 +50,13 @@
 
 // Consider updating MAXSIZE_ENVKEY if you change these values...
 /* module papi */
-#define MAXNUM_PAPI_EVENTS      1024
-#define MAXNUM_PAPI_COUNTERS    1024
+#define MAXNUM_PAPI_EVENTS      512
+#define MAXNUM_PAPI_COUNTERS    512
 #define MAXNUM_PAPI_COMPONENTS  1
 #define MAXSIZE_PAPI_EVTNAME    32
 
 /* module omptracepoints */
-#define MAXNUM_THREADS          128
+#define MAXNUM_THREADS          276
 
 
 #endif /* IPM_SIZES_INCLUDED */

--- a/include/ipm_sizes.h
+++ b/include/ipm_sizes.h
@@ -48,10 +48,11 @@
 #define MAXSIZE_CYCLE            128
 #define MAXNUM_CYCLES            128
 
+// Consider updating MAXSIZE_ENVKEY if you change these values...
 /* module papi */
-#define MAXNUM_PAPI_EVENTS      16
-#define MAXNUM_PAPI_COUNTERS    8
-#define MAXNUM_PAPI_COMPONENTS  8 
+#define MAXNUM_PAPI_EVENTS      32
+#define MAXNUM_PAPI_COUNTERS    16
+#define MAXNUM_PAPI_COMPONENTS  1
 #define MAXSIZE_PAPI_EVTNAME    32
 
 /* module omptracepoints */

--- a/include/mod_mpi.h
+++ b/include/mod_mpi.h
@@ -23,7 +23,6 @@ typedef struct mpidata
   double mtime_e;
 } mpidata_t;
 
-extern mpidata_t mpidata[MAXNUM_REGIONS];
 extern MPI_Group ipm_world_group;
 
 #define IPM_MPI_MAP_RANK(rank_out_, rank_in_, comm_) \

--- a/include/mod_papi.h
+++ b/include/mod_papi.h
@@ -25,6 +25,7 @@ typedef struct
   int evtset;
   int nevts;
   short ctr2evt[MAXNUM_PAPI_COUNTERS];
+  int domain;
 } ipm_papi_evtset_t;
 
 int mod_papi_init(ipm_mod_t *mod, int flags);

--- a/include/mod_papi.h
+++ b/include/mod_papi.h
@@ -27,9 +27,6 @@ typedef struct
   short ctr2evt[MAXNUM_PAPI_COUNTERS];
 } ipm_papi_evtset_t;
 
-extern ipm_papi_event_t papi_events[MAXNUM_PAPI_EVENTS];
-extern ipm_papi_evtset_t papi_evtset[MAXNUM_PAPI_COMPONENTS];
-
 int mod_papi_init(ipm_mod_t *mod, int flags);
 
 int ipm_papi_read(long long *val);

--- a/include/mod_pmon.h
+++ b/include/mod_pmon.h
@@ -13,6 +13,8 @@ typedef struct ipm_pmon
 
     double mem_initial_energy;
     double mem_final_energy;
+
+    double mtime;
 } ipm_pmon_t;
 
 int mod_pmi_xml(ipm_mod_t* mod, void* ptr, struct region* reg);

--- a/include/mod_pmon.h
+++ b/include/mod_pmon.h
@@ -13,13 +13,8 @@ typedef struct ipm_pmon
 
     double mem_initial_energy;
     double mem_final_energy;
-
-    double mtime;
 } ipm_pmon_t;
 
-int mod_pmi_xml(ipm_mod_t* mod, void* ptr, struct region* reg);
-int mod_pmon_finalize(ipm_mod_t* mod, int flags);
-int mod_pmon_region(ipm_mod_t* mod, int op, struct region* reg);
 int mod_pmon_init(ipm_mod_t* mod, int flags);
 double ipm_pmon_get_region_energy(int id);
 

--- a/include/perfdata.h
+++ b/include/perfdata.h
@@ -36,6 +36,10 @@
 #include "mod_omptracepoints.h"
 #endif
 
+#ifdef HAVE_PAPI
+#include "mod_papi.h"
+#endif
+
 #ifdef HAVE_PMON
 #include "mod_pmon.h"
 #endif
@@ -122,6 +126,13 @@ mpidata_t mpidata[MAXNUM_REGIONS];
 
 #ifdef HAVE_OMPTRACEPOINTS
   ompdata_t ompdata[MAXNUM_REGIONS];
+#endif
+
+#ifdef HAVE_PAPI
+ipm_papi_event_t papi_events[MAXNUM_PAPI_EVENTS];
+ipm_papi_evtset_t papi_evtset[MAXNUM_PAPI_COMPONENTS];
+const PAPI_component_info_t* cmpinfo;
+PAPI_option_t papi_mpx_interval;
 #endif
 
 #ifdef HAVE_PMON

--- a/include/perfdata.h
+++ b/include/perfdata.h
@@ -74,7 +74,8 @@ typedef struct taskdata
   double wtime, stime, utime, mtime, iotime, omptime, ompidletime; 
 
   double procmem;
-
+  
+  unsigned int num_threads;
   int nhosts;
   int par_env;
   char user[MAXSIZE_USERNAME];

--- a/include/perfdata.h
+++ b/include/perfdata.h
@@ -12,6 +12,10 @@
 #include "ipm_types.h"
 #include "regstack.h"
 
+#ifdef HAVE_MPI
+#include "mod_mpi.h"
+#endif
+
 #ifdef HAVE_POSIXIO
 #include "mod_posixio.h"
 #endif
@@ -30,6 +34,10 @@
 
 #ifdef HAVE_OMPTRACEPOINTS
 #include "mod_omptracepoints.h"
+#endif
+
+#ifdef HAVE_PMON
+#include "mod_pmon.h"
 #endif
 
 typedef struct jobdata 
@@ -92,6 +100,10 @@ typedef struct taskdata
 
   struct region *rstack;
 
+#ifdef HAVE_MPI
+mpidata_t mpidata[MAXNUM_REGIONS];
+#endif
+
 #ifdef HAVE_POSIXIO
   iodata_t iodata[MAXNUM_REGIONS];
 #endif
@@ -110,6 +122,10 @@ typedef struct taskdata
 
 #ifdef HAVE_OMPTRACEPOINTS
   ompdata_t ompdata[MAXNUM_REGIONS];
+#endif
+
+#ifdef HAVE_PMON
+ipm_pmon_t pmondata[MAXNUM_REGIONS];
 #endif
 
 } taskdata_t;

--- a/src/ipm_env.c
+++ b/src/ipm_env.c
@@ -13,20 +13,21 @@
 extern char **environ;
 
 
-#define ENV_DEBUG          0
-#define ENV_REPORT         1
-#define ENV_LOG            2
-#define ENV_LOGDIR         3
-#define ENV_HPM            4
-#define ENV_OUTFILE        5
-#define ENV_LOGWRITER      6
-#define ENV_HPCNAME        7
+#define ENV_DEBUG           0
+#define ENV_REPORT          1
+#define ENV_LOG             2
+#define ENV_LOGDIR          3
+#define ENV_HPM             4
+#define ENV_OUTFILE         5
+#define ENV_LOGWRITER       6
+#define ENV_HPCNAME         7
 #ifdef HAVE_SNAP
-#define ENV_SNAP           8
+#define ENV_SNAP            8
 #endif
-#define ENV_NESTED_REGIONS 9
+#define ENV_NESTED_REGIONS  9
 #ifdef HAVE_PMON
-#define ENV_PMON 10
+#define ENV_PMON            10
+#define ENV_OMP_NUM_THREADS 11
 #endif
 
 
@@ -82,14 +83,13 @@ int ipm_get_env()
 
   cp=environ;
   while(str=(*cp)) {
-    if( strncmp(str,"IPM", 3)!=0 ) {
+    if( strncmp(str,"IPM", 3)!=0  && strncmp(str, "OMP", 3) != 0) {
       cp++;
       continue;
     }
 
     ipm_tokenize(str,key,val);
     len = strlen(key);
-
     /* IPM_DEBUG */
     if(!strcmp("IPM_DEBUG", key)) {
       ipm_check_env(ENV_DEBUG, val);
@@ -143,6 +143,10 @@ int ipm_get_env()
 
     else if(!strcmp("IPM_NESTED_REGIONS", key)) {
       ipm_check_env(ENV_NESTED_REGIONS, val);
+    }
+    
+    else if(!strcmp("OMP_NUM_THREADS", key)) {
+      ipm_check_env(ENV_OMP_NUM_THREADS, val);
     }
 
     /* do not complain about these */
@@ -282,6 +286,10 @@ int ipm_check_env(int env, char *val)
     case ENV_NESTED_REGIONS:
       task.flags |= FLAG_NESTED_REGIONS;
       break;
+
+    case ENV_OMP_NUM_THREADS:
+        task.num_threads = atoi(val);
+    break;
 
     default:
       ;

--- a/src/ipm_env.c
+++ b/src/ipm_env.c
@@ -257,7 +257,7 @@ int ipm_check_env(int env, char *val)
 	/* User defined list of counters */
 	cptr1 = strtok_r(val,",",&uptr);
 	while (cptr1){
-	  strcpy(papi_events[i].name, cptr1);
+	  strcpy(task.papi_events[i].name, cptr1);
 	  cptr1 = strtok_r(NULL,",",&uptr);
 	  i++;
 	}

--- a/src/ipm_env.c
+++ b/src/ipm_env.c
@@ -30,7 +30,7 @@ extern char **environ;
 #endif
 
 
-#define MAXSIZE_ENVKEY  120
+#define MAXSIZE_ENVKEY  1024
 
 int ipm_check_env(int env, char*val);
 

--- a/src/machtopo.c
+++ b/src/machtopo.c
@@ -13,8 +13,8 @@
 void ipm_get_machtopo()
 {
   unsigned i, j, np;
-  char *allnames;
-  char *unique;
+  char *allnames = NULL;
+  char *unique = NULL;
   unsigned nunique;
   int x;
 

--- a/src/mod_mpi.c
+++ b/src/mod_mpi.c
@@ -11,8 +11,6 @@
 char* ipm_mpi_op[MAXNUM_MPI_OPS];
 char* ipm_mpi_type[MAXNUM_MPI_TYPES];
 
-mpidata_t mpidata[MAXNUM_REGIONS];
-
 MPI_Group ipm_world_group;
 
 int mod_mpi_xml(ipm_mod_t* mod, void *ptr, struct region *reg);
@@ -36,8 +34,8 @@ int mod_mpi_init(ipm_mod_t* mod, int flags)
   copy_mpi_calltable();
 
   for( i=0; i<MAXNUM_REGIONS; i++ ) {
-    mpidata[i].mtime=0.0;
-    mpidata[i].mtime_e=0.0;
+    task.mpidata[i].mtime=0.0;
+    task.mpidata[i].mtime_e=0.0;
   }
 
   for( i=0; i<MAXNUM_MPI_OPS; i++ ) {
@@ -150,12 +148,12 @@ int mod_mpi_xml(ipm_mod_t* mod, void *ptr, struct region *reg)
     time = ipm_mtime();
   }
   else {
-    time = mpidata[reg->id].mtime;
+    time = task.mpidata[reg->id].mtime;
 
     if( (reg->flags)&FLAG_PRINT_EXCLUSIVE ) {
       tmp = reg->child;
       while(tmp) {
-	time -= mpidata[tmp->id].mtime;
+	time -= task.mpidata[tmp->id].mtime;
 	tmp = tmp->next;
       }
     }
@@ -179,11 +177,11 @@ int mod_mpi_region(ipm_mod_t *mod, int op, struct region *reg)
   switch(op) 
     {
     case -1: /* exit */
-      mpidata[reg->id].mtime += (mtime - (mpidata[reg->id].mtime_e));
+      task.mpidata[reg->id].mtime += (mtime - (task.mpidata[reg->id].mtime_e));
       break;
       
     case 1: /* enter */
-      mpidata[reg->id].mtime_e=mtime;
+      task.mpidata[reg->id].mtime_e=mtime;
       break;
   }
 

--- a/src/mod_papi.c
+++ b/src/mod_papi.c
@@ -20,15 +20,6 @@
 // components they are supported on - this would be the better way to determine
 // which events to monitor.
 
-/* 
-   uncomment the following #define to enable multiplexing, 
-   also check the number of supported counters per PAPI component 
-   (MAXNUM_PAPI_COUNTERS) and the overall number of events supported 
-   (MAXNUM_PAPI_EVENTS) - you might want to have both of these larger 
-   when multiplexing is enabled. 
-*/
-//#define USE_PAPI_MULTIPLEXING
-
 double flops_weight[MAXNUM_PAPI_EVENTS];
 
 int ipm_papi_start();
@@ -51,17 +42,20 @@ int mod_papi_region(ipm_mod_t* mod, int op, struct region* reg)
             break;
         }
     }
+    return 0;
 }
 
 int mod_papi_xml(ipm_mod_t* mod, void* ptr, struct region* reg)
 {
     int res = 0;
     const PAPI_hw_info_t *hwinfo = PAPI_get_hardware_info();
+    
     // time here for compatibility with standard - papi has no interactive regions
     res += ipm_printf(ptr, "<module name=\"PAPI\" time=\"0.0\" ncpu=\"%d\" nnodes=\"%d\" totalcpus=\"%d\"\
- vendor=\"%d\" vendor_string=\"%s\" model=\"%d\" model_string=\"%s\" revision=\"%f\" mhz=\"%f\"></module>\n",
+ vendor=\"%d\" vendor_string=\"%s\" model=\"%d\" model_string=\"%s\" revision=\"%f\" min_mhz=\"%d\" max_mhz=\"%d\" domain=\"%d\"></module>\n",
                        hwinfo->ncpu, hwinfo->nnodes, hwinfo->totalcpus, hwinfo->vendor, hwinfo->vendor_string,
-                       hwinfo->model, hwinfo->model_string, hwinfo->revision, hwinfo->mhz);
+                       hwinfo->model, hwinfo->model_string, hwinfo->revision, hwinfo->cpu_min_mhz, hwinfo->cpu_max_mhz, task.papi_evtset[0].domain);
+    //res += ipm_printf(ptr, " min_mhz=\"%d\" max_mhz=\"%d\" domain=\"%d\"></module>\n", hwinfo->cpu_min_mhz, hwinfo->cpu_max_mhz, task.papi_evtset[0].domain);
 
     return res;
 }
@@ -82,6 +76,7 @@ int mod_papi_init(ipm_mod_t* mod, int flags)
   for( comp=0; comp<MAXNUM_PAPI_COMPONENTS; comp++ ) {
     task.papi_evtset[comp].nevts=0;
     task.papi_evtset[comp].evtset=PAPI_NULL;
+    task.papi_evtset[comp].domain = PAPI_DOM_ALL;
   }
 
   // clear events

--- a/src/mod_papi.c
+++ b/src/mod_papi.c
@@ -51,9 +51,9 @@ int mod_papi_xml(ipm_mod_t* mod, void* ptr, struct region* reg)
     const PAPI_hw_info_t *hwinfo = PAPI_get_hardware_info();
     
     // time here for compatibility with standard - papi has no interactive regions
-    res += ipm_printf(ptr, "<module name=\"PAPI\" time=\"0.0\" ncpu=\"%d\" nnodes=\"%d\" totalcpus=\"%d\"\
+    res += ipm_printf(ptr, "<module name=\"PAPI\" time=\"0.0\" ncpu=\"%d\" nnodes=\"%d\" totalcpus=\"%d\" threads=\"%d\" cores=\"%d\" \
  vendor=\"%d\" vendor_string=\"%s\" model=\"%d\" model_string=\"%s\" revision=\"%f\" min_mhz=\"%d\" max_mhz=\"%d\" domain=\"%d\"></module>\n",
-                       hwinfo->ncpu, hwinfo->nnodes, hwinfo->totalcpus, hwinfo->vendor, hwinfo->vendor_string,
+                       hwinfo->ncpu, hwinfo->nnodes, hwinfo->totalcpus, hwinfo->threads, hwinfo->cores, hwinfo->vendor, hwinfo->vendor_string,
                        hwinfo->model, hwinfo->model_string, hwinfo->revision, hwinfo->cpu_min_mhz, hwinfo->cpu_max_mhz, task.papi_evtset[0].domain);
     //res += ipm_printf(ptr, " min_mhz=\"%d\" max_mhz=\"%d\" domain=\"%d\"></module>\n", hwinfo->cpu_min_mhz, hwinfo->cpu_max_mhz, task.papi_evtset[0].domain);
 

--- a/src/mod_papi.c
+++ b/src/mod_papi.c
@@ -35,8 +35,9 @@ int mod_papi_xml(ipm_mod_t* mod, void* ptr, struct region* reg)
 {
     int res = 0;
     const PAPI_hw_info_t *hwinfo = PAPI_get_hardware_info();
-    res += ipm_printf(ptr, "<module name=\"PAPI\" ncpu=\"%d\" nnodes=\"%d\" totalcpus=\"%d\"\
- vendor=\"%d\" vendor_string=\"%s\" model=\"%d\" model_string=\"%s\" revision=\"%f\" mhz=\"%f\">\n",
+    // time here for compatibility with standard - papi has no interactive regions
+    res += ipm_printf(ptr, "<module name=\"PAPI\" time=\"0.0\" ncpu=\"%d\" nnodes=\"%d\" totalcpus=\"%d\"\
+ vendor=\"%d\" vendor_string=\"%s\" model=\"%d\" model_string=\"%s\" revision=\"%f\" mhz=\"%f\"></module>\n",
                        hwinfo->ncpu, hwinfo->nnodes, hwinfo->totalcpus, hwinfo->vendor, hwinfo->vendor_string,
                        hwinfo->model, hwinfo->model_string, hwinfo->revision, hwinfo->mhz);
 

--- a/src/mod_papi.c
+++ b/src/mod_papi.c
@@ -13,6 +13,13 @@
 #include "mod_papi.h"
 #include "report.h"
 
+// tallen: previous versions of this code naively assumed all events were 
+// compatible with all components. This is not the case. The current code
+// only supports core events located by default at index 0. Additional code
+// will have to be added to support other events. Events can look up what
+// components they are supported on - this would be the better way to determine
+// which events to monitor.
+
 /* 
    uncomment the following #define to enable multiplexing, 
    also check the number of supported counters per PAPI component 
@@ -20,7 +27,7 @@
    (MAXNUM_PAPI_EVENTS) - you might want to have both of these larger 
    when multiplexing is enabled. 
 */
-/* #define USE_PAPI_MULTIPLEXING */
+//#define USE_PAPI_MULTIPLEXING
 
 double flops_weight[MAXNUM_PAPI_EVENTS];
 ipm_papi_event_t papi_events[MAXNUM_PAPI_EVENTS];
@@ -55,23 +62,17 @@ int mod_papi_init(ipm_mod_t* mod, int flags)
   mod->finalize = 0;
   mod->name     = "PAPI";
 
+  // intialize components
   for( comp=0; comp<MAXNUM_PAPI_COMPONENTS; comp++ ) {
     papi_evtset[comp].nevts=0;
     papi_evtset[comp].evtset=PAPI_NULL;
   }
 
+  // clear events
   for(i=0; i<MAXNUM_PAPI_EVENTS; i++ ) {
     papi_events[i].code=0;
-//    papi_events[i].name[0]=0;
     flops_weight[i]=0.0;
   }
-  /*
-     sprintf(papi_events[0].name, "PAPI_FP_OPS");
-     sprintf(papi_events[1].name, "PAPI_L2_TCM");
-     sprintf(papi_events[1].name, "ETH0_RX_PACKETS");
-     sprintf(papi_events[MAXNUM_PAPI_EVENTS-1].name, "PAPI_TOT_INS");
-  */
-
 
   rv = ipm_papi_init();
   if(rv!=IPM_OK) {
@@ -92,184 +93,182 @@ int mod_papi_init(ipm_mod_t* mod, int flags)
 
 int ipm_papi_init()
 {
-  int i, rv;
+    int i, rv;
 
-  rv=PAPI_library_init( PAPI_VER_CURRENT );
+    rv=PAPI_library_init( PAPI_VER_CURRENT );
 
-  if( rv!=PAPI_VER_CURRENT && rv>0 ) {
-    IPMDBG("PAPI library version mismatch\n");
-    return IPM_EOTHER;
-  } else if( rv<0 ) {
-    IPMERR("PAPI initialization error (%d)\n", rv);
-    return IPM_EOTHER;
-  }      
+    if( rv!=PAPI_VER_CURRENT && rv>0 ) {
+        IPMDBG("PAPI library version mismatch\n");
+        return IPM_EOTHER;
+    } else if( rv<0 ) {
+        IPMERR("PAPI initialization error (%d)\n", rv);
+        return IPM_EOTHER;
+    }      
 
-  if( PAPI_VERSION>=PAPI_VERSION_NUMBER(3,9,0,0) ) {
-    IPMDBG("Detected component PAPI (PAPI-C). Max %d components supported by IPM\n", 
-	   MAXNUM_PAPI_COMPONENTS);
-  } else {
-    IPMDBG("Detected classic PAPI. One default (CPU) component supported\n");
-  }
-  
+    if( PAPI_VERSION>=PAPI_VERSION_NUMBER(3,9,0,0) ) {
+        IPMDBG("Detected component PAPI (PAPI-C). Max %d components supported by IPM\n", 
+        MAXNUM_PAPI_COMPONENTS);
+    } else {
+        IPMDBG("Detected classic PAPI. One default (CPU) component supported\n");
+    }
+
 #ifdef USE_PAPI_MULTIPLEXING
-  rv=PAPI_multiplex_init();
-  if( rv!=PAPI_OK ) {
-    IPMERR("PAPI_multiplex_init() failed.\n");
-  }
+    rv=PAPI_multiplex_init();
+    if( rv!=PAPI_OK ) {
+        IPMERR("PAPI_multiplex_init() failed.\n");
+    }
 #endif
 
-  /* translate PAPI event names to codes and check validity */
-  for( i=0; i<MAXNUM_PAPI_EVENTS; i++ ) {
-    if( papi_events[i].name[0] ) {
-      PAPI_event_name_to_code(papi_events[i].name, &(papi_events[i].code));
-        
-      if( PAPI_query_event(papi_events[i].code)!=PAPI_OK )
-	{
-	  IPMERR("PAPI: Event name-to-code error: %s, ignoring\n",
-		 papi_events[i].name);
-	  papi_events[i].name[0]=0;
-	  papi_events[i].code=0;
-	}
-      else
-	{
-	  if( !strcmp(papi_events[i].name, "PAPI_FP_OPS") ) {
-	    flops_weight[i]=1.0;
-	  }
-	  IPMDBG("PAPI: Successfully registered event: %s\n", 
-		 papi_events[i].name);
-	}
+    /* translate PAPI event names to codes and check validity */
+    for( i=0; i<MAXNUM_PAPI_EVENTS; i++ ) {
+        if( papi_events[i].name[0] ) {
+            PAPI_event_name_to_code(papi_events[i].name, &(papi_events[i].code));
+
+            if( PAPI_query_event(papi_events[i].code)!=PAPI_OK )
+            {
+                IPMERR("PAPI: Event name-to-code error: %s, ignoring\n",
+                papi_events[i].name);
+                papi_events[i].name[0]=0;
+                papi_events[i].code=0;
+            }
+            else
+            {
+                if( !strcmp(papi_events[i].name, "PAPI_FP_OPS") ) {
+                    flops_weight[i]=1.0;
+                }
+                IPMDBG("PAPI: Successfully registered event: %s\n", 
+                papi_events[i].name);
+            }
+        }
     }
-  }
-  
-  return IPM_OK;
+
+    return IPM_OK;
 }
 
 
 int ipm_papi_start()
 {
-  int i, comp, rv;
+    int i, rv;
+    const PAPI_component_info_t* cmpinfo = NULL;
 
-  for( comp=0; comp<MAXNUM_PAPI_COMPONENTS; comp++ ) 
-    {
-      papi_evtset[comp].evtset=PAPI_NULL;
-      rv = PAPI_create_eventset(&(papi_evtset[comp].evtset));
+    // count events during all contexts (user, kernel, etc)
+    rv = PAPI_set_domain(PAPI_DOM_ALL);
+    cmpinfo = PAPI_get_component_info( 0 );
+    if ( cmpinfo == NULL )
+        IPMDBG("BUG: No core component found by PAPI\n");
+    papi_evtset[0].evtset=PAPI_NULL;
+    rv = PAPI_create_eventset(&(papi_evtset[0].evtset));
+    // attach eventset to appropriate component - currently just cpu
+    // tyler: seems to be necessary for multiplexing
+    rv = PAPI_assign_eventset_component( papi_evtset[0].evtset, 0 );
 
-      if( rv!= PAPI_OK )    {
-	IPMERR("PAPI: [comp %d] Error creating eventset\n", comp);
-	return IPM_EOTHER;
-      }
+    if( rv!= PAPI_OK )    {
+        IPMERR("PAPI: [comp %d] Error creating eventset: %s\n", 0, PAPI_strerror(rv));
+        return IPM_EOTHER;
+    }
 
 #ifdef USE_PAPI_MULTIPLEXING
-      rv = PAPI_set_multiplex(papi_evtset[comp].evtset);
-      if( rv!= PAPI_OK )    {
-	IPMDBG("PAPI: [comp %d] Error calling set_multiplex\n", comp);
-      }
-#endif
-    }
-  
-  for( i=0; i<MAXNUM_PAPI_EVENTS; i++ ) {
-    if( !(papi_events[i].name[0]) )
-      continue;
-
-    comp = PAPI_COMPONENT_INDEX(papi_events[i].code);
-
-    rv = PAPI_add_event(papi_evtset[comp].evtset, 
-			papi_events[i].code);
-    
+    rv = PAPI_set_multiplex(papi_evtset[0].evtset);
     if( rv!= PAPI_OK ) {
-      IPMERR("PAPI: [comp %d] Error adding event to eventset: %s, skipping\n",
-	     comp, papi_events[i].name);
-      
-    } else {
-      IPMDBG("PAPI: [comp %d] Successfully added event: %s\n",
-	     comp, papi_events[i].name);
-      
-      papi_evtset[comp].ctr2evt[papi_evtset[comp].nevts]=i;
-      
-      papi_evtset[comp].nevts++;
+        IPMDBG("PAPI: [comp %d] Error calling set_multiplex\n", 0);
     }
-  }
-  
-  for( comp=0; comp<MAXNUM_PAPI_COMPONENTS; comp++ ) 
-    {
-      if( papi_evtset[comp].nevts>0 ) {
-	rv = PAPI_start(papi_evtset[comp].evtset);
-	
-	if( rv!=PAPI_OK ) {
-	  IPMERR("PAPI: [comp %d] Error starting eventset (%d events)\n",
-		 comp, papi_evtset[comp].nevts);
-	  papi_evtset[comp].nevts=0;
-	} else {
-	  IPMDBG("PAPI: [comp %d] Successfully started eventset (%d events)\n",
-		 comp, papi_evtset[comp].nevts);
-	}
-      }
+#endif
+
+    // add events
+    for( i=0; i<MAXNUM_PAPI_EVENTS; i++ ) {
+        if( !(papi_events[i].name[0]) )
+            continue;
+
+        rv = PAPI_add_event(papi_evtset[0].evtset, papi_events[i].code);
+        // if an event is listed more than once, the -8 lacking-hardware error
+        // will be given. behavior undefined for papi and ipm
+        if( rv!= PAPI_OK ) {
+            IPMERR("PAPI: [comp %d] Error adding event to eventset: %s, %s, skipping\n",
+            0, papi_events[i].name, PAPI_strerror(rv));
+
+        } else {
+            IPMDBG("PAPI: [comp %d] Successfully added event: %s\n",
+            0, papi_events[i].name);
+
+            papi_evtset[0].ctr2evt[papi_evtset[0].nevts]=i;
+
+            papi_evtset[0].nevts++;
+        }
     }
 
-  return IPM_OK;
+    // start papi
+    if( papi_evtset[0].nevts>0 ) {
+        rv = PAPI_start(papi_evtset[0].evtset);
+        if( rv!=PAPI_OK ) {
+            IPMERR("PAPI: [comp %d] Error starting eventset (%d events)\n",
+            0, papi_evtset[0].nevts);
+            papi_evtset[0].nevts=0;
+        } else {
+            IPMDBG("PAPI: [comp %d] Successfully started eventset (%d events)\n",
+            0, papi_evtset[0].nevts);
+        }
+    }
+
+    return IPM_OK;
 }
 
 int ipm_papi_stop() 
 {
-  int comp, rv;
-  long long ctr[MAXNUM_PAPI_EVENTS];
+    int rv;
+    long long ctr[MAXNUM_PAPI_EVENTS];
 
-  for( comp=0; comp<MAXNUM_PAPI_COMPONENTS; comp++ ) 
-    {
-      if( papi_evtset[comp].nevts>0 ) {
-	rv =  PAPI_stop(papi_evtset[comp].evtset, ctr);
-	if( rv!=PAPI_OK ) {
-	  IPMERR("PAPI: [comp %d] Error stopping eventset\n", comp);
-	  return IPM_EOTHER;
-	} else {
-	  IPMDBG("PAPI: [comp %d] Successfully stopped eventset\n", comp);
-	}
-	
-	rv =  PAPI_cleanup_eventset(papi_evtset[comp].evtset);
-	if( rv!=PAPI_OK ) {
-	  IPMERR("PAPI: [comp %d] Error cleaning eventset up\n", comp);
-	  return IPM_EOTHER;
-	} else {
-	  IPMDBG("PAPI: [comp %d] Successfully cleaned eventset up\n", comp);
-	}
-	
-	rv =  PAPI_destroy_eventset(&(papi_evtset[comp].evtset));
-	if( rv!=PAPI_OK ) {
-	  IPMERR("PAPI: [comp %d] Error destroying eventset\n", comp);
-	  return IPM_EOTHER;
-	} else {
-	  IPMDBG("PAPI: [comp %d] Successfully destroyed eventset\n", comp);
-	}
-      }
-  }
-  return IPM_OK;
+    if( papi_evtset[0].nevts>0 ) {
+        rv =  PAPI_stop(papi_evtset[0].evtset, ctr);
+        if( rv!=PAPI_OK ) {
+            IPMERR("PAPI: [comp %d] Error stopping eventset\n", 0);
+            return IPM_EOTHER;
+        } else {
+            IPMDBG("PAPI: [comp %d] Successfully stopped eventset\n", 0);
+        }
+
+        rv =  PAPI_cleanup_eventset(papi_evtset[0].evtset);
+        if( rv!=PAPI_OK ) {
+            IPMERR("PAPI: [comp %d] Error cleaning eventset up\n", 0);
+            return IPM_EOTHER;
+        } else {
+            IPMDBG("PAPI: [comp %d] Successfully cleaned eventset up\n", 0);
+        }
+
+        rv =  PAPI_destroy_eventset(&(papi_evtset[0].evtset));
+        if( rv!=PAPI_OK ) {
+            IPMERR("PAPI: [comp %d] Error destroying eventset\n", 0);
+            return IPM_EOTHER;
+        } else {
+            IPMDBG("PAPI: [comp %d] Successfully destroyed eventset\n", 0);
+        }
+    }
+    return IPM_OK;
 }
 
 int ipm_papi_read(long long *val)
 {
-  int i, comp, rv;
-  long long ctr[MAXNUM_PAPI_COUNTERS];
+    int i, rv;
+    long long ctr[MAXNUM_PAPI_COUNTERS];
 
-  for( comp=0; comp<MAXNUM_PAPI_COMPONENTS; comp++ ) 
-    {
-      if( papi_evtset[comp].nevts>0 ) {
-	rv =  PAPI_read(papi_evtset[comp].evtset, ctr);
-	if( rv!=PAPI_OK ) {
-	  IPMERR("PAPI: [comp %d] Error reading eventset\n", comp);
-	  return IPM_EOTHER;
-	} else 
-	  {
-	    for( i=0; i<papi_evtset[comp].nevts; i++ ) {
-	      val[ papi_evtset[comp].ctr2evt[i] ] = ctr[i];
-	    }
-	  }
-      }
+    if( papi_evtset[0].nevts>0 ) {
+        rv =  PAPI_read(papi_evtset[0].evtset, ctr);
+        if( rv!=PAPI_OK ) {
+            IPMERR("PAPI: [comp %d] Error reading eventset\n", 0);
+            return IPM_EOTHER;
+        } else {
+            for( i=0; i<papi_evtset[0].nevts; i++ ) {
+                val[ papi_evtset[0].ctr2evt[i] ] = ctr[i];
+            }
+        }
     }
 
-  return IPM_OK;
+    return IPM_OK;
 }
 
-
+// tyler:
+// this function's current use is strange; used to report during banner call,
+// fails to provide the right value as it is always called from rank==0 once
+// per process
 double ipm_papi_gflops(long long *ctr, double time)
 {
   int i;

--- a/src/mod_papi.c
+++ b/src/mod_papi.c
@@ -28,6 +28,7 @@ int ipm_papi_init();
 
 int mod_papi_region(ipm_mod_t* mod, int op, struct region* reg)
 {
+    int i;
     if (reg)
     {
         switch (op)
@@ -35,9 +36,18 @@ int mod_papi_region(ipm_mod_t* mod, int op, struct region* reg)
             //end
             case -1:
                 ipm_papi_read(reg->ctr);
+                for (i = 0; i < task.papi_evtset[0].nevts; i++)
+                {
+                    reg->ctr[i] -= reg->ctr_e[i];
+                }
             break;
             // start
             case 1:
+                for (i = 0; i < task.papi_evtset[0].nevts; i++)
+                {
+                    reg->ctr[i] = 0;
+                    reg->ctr_e[i] = 0;
+                }
                 ipm_papi_read(reg->ctr_e);
             break;
         }

--- a/src/mod_papi.c
+++ b/src/mod_papi.c
@@ -123,6 +123,9 @@ int ipm_papi_init()
         IPMDBG("Detected classic PAPI. One default (CPU) component supported\n");
     }
 
+    //if (PAPI_thread_init((unsigned long(*)(void))omp_get_thread_num) != PAPI_OK)
+    //    IPMERR("PAPI_thread_init() failed.\n");
+
 #ifdef USE_PAPI_MULTIPLEXING
     rv=PAPI_multiplex_init();
     if( rv!=PAPI_OK ) {

--- a/src/mod_pmon.c
+++ b/src/mod_pmon.c
@@ -15,12 +15,14 @@ static void parse_pm_counter(const char* file, double* val)
         if(fscanf(F, "%lf", val) != 1)
         {
             *val = 0.0;
+            IPMERR("Warning: Cray Power File not readable.");
         }
         fclose(F);
     }
     else
     {
         *val = 0.0;
+        IPMERR("Warning: Cray Power File not found or insufficient permissions to open.");
     }
 }
 
@@ -108,7 +110,6 @@ int mod_pmon_region(ipm_mod_t* mod, int op, struct region* reg)
 int mod_pmon_init(ipm_mod_t* mod, int flags)
 {
   int i;
-
   mod->state    = STATE_IN_INIT;
   mod->init     = mod_pmon_init;
   mod->output   = 0;//mod_pmon_output;

--- a/src/mod_posixio.c
+++ b/src/mod_posixio.c
@@ -92,8 +92,6 @@ int mod_posixio_xml(ipm_mod_t* mod, void *ptr, struct region *reg)
 int mod_posixio_region(ipm_mod_t *mod, int op, struct region *reg)
 {
   double time;
-  char host[256];
-  gethostname(host, 256);
   if( !reg ) return 0;
 
   time = ipm_iotime();

--- a/src/mod_posixio.c
+++ b/src/mod_posixio.c
@@ -92,6 +92,8 @@ int mod_posixio_xml(ipm_mod_t* mod, void *ptr, struct region *reg)
 int mod_posixio_region(ipm_mod_t *mod, int op, struct region *reg)
 {
   double time;
+  char host[256];
+  gethostname(host, 256);
   if( !reg ) return 0;
 
   time = ipm_iotime();

--- a/src/mpi_pcontrol.c
+++ b/src/mpi_pcontrol.c
@@ -24,7 +24,7 @@
 
 int ipm_control(const int ctl, char *cmd, void *data) 
 {
-  char *reg;
+  char *reg = NULL;
   
   switch( ctl ) 
     {

--- a/src/perfdata.c
+++ b/src/perfdata.c
@@ -33,6 +33,8 @@ void taskdata_init(taskdata_t *t)
   t->omptime  = ipm_omptime();
 
   t->procmem = 0.0;
+  
+  t->num_threads = 1;
 
   gethostname(t->hostname, MAXSIZE_HOSTNAME);
   t->hostname[MAXSIZE_HOSTNAME-1]=0;

--- a/src/regstack.c
+++ b/src/regstack.c
@@ -119,7 +119,7 @@ void ipm_region_end(struct region *reg)
   int i;
 
 #ifdef HAVE_PAPI
-  long long ctr1[MAXNUM_PAPI_EVENTS];
+//  long long ctr1[MAXNUM_PAPI_EVENTS];
   //  long long ctr2[MAXNUM_PAPI_EVENTS];
 #endif
 
@@ -127,7 +127,7 @@ void ipm_region_end(struct region *reg)
    */
 
 #ifdef HAVE_PAPI
-  ipm_papi_read(ctr1);
+ // ipm_papi_read(ctr1);
 #endif
   
   /* update data for region 'reg' */
@@ -144,10 +144,12 @@ void ipm_region_end(struct region *reg)
 
 #ifdef HAVE_PAPI
   // ipm_papi_read(ctr2);
+  /*
   for( i=0; i<MAXNUM_PAPI_EVENTS; i++ ) {
     //reg->ctr_ipm[i] += (ctr2[i]-ctr1[i]);
     reg->ctr[i] += (ctr1[i]-reg->ctr_e[i]);
   }
+    */
 #endif
 
 }
@@ -311,6 +313,7 @@ void* rsfunc_enum_l1_regions(region_t *reg, unsigned level, int flags, void *ptr
   return ptr;
 }
 
+/* tallen: never used
 void* rsfunc_adjust_ctrs(region_t *reg, unsigned level, int flags, void *ptr) 
 {
   int i;
@@ -320,7 +323,7 @@ void* rsfunc_adjust_ctrs(region_t *reg, unsigned level, int flags, void *ptr)
     return ptr;
 
 #ifdef HAVE_PAPI
-  /* we are at a child or backtracking */
+  // we are at a child or backtracking 
   tmp = reg->child; 
   while(tmp) {
     for( i=0; i<MAXNUM_PAPI_EVENTS; i++ ) {
@@ -332,11 +335,11 @@ void* rsfunc_adjust_ctrs(region_t *reg, unsigned level, int flags, void *ptr)
   for( i=0; i<MAXNUM_PAPI_EVENTS; i++ ) {
     reg->ctr[i] -= reg->ctr_ipm[i];
   }
-#endif /* HAVE_PAPI */
+#endif  HAVE_PAPI 
   
   return ptr;
 }
-
+*/
 
 void* rsfunc_find_by_id(region_t *reg, unsigned level, int flags, void *ptr) 
 {

--- a/src/regstack.c
+++ b/src/regstack.c
@@ -81,18 +81,6 @@ void ipm_region_begin(struct region *reg)
 {
   int i;
 
-#ifdef HAVE_PAPI
-  //long long ctr1[MAXNUM_PAPI_EVENTS];
-  long long ctr2[MAXNUM_PAPI_EVENTS];
-#endif
-  
-#ifdef HAVE_PAPI
-  //ipm_papi_read(ctr1);
-#endif 
-
-  /* fprintf(stderr, "region_begin for reg=%x '%s'\n", reg, reg->name);
-   */
-
   /* update enter stats for ipm_rstackptr */
   reg->wtime_e = ipm_wtime();
   reg->utime_e = ipm_utime();
@@ -104,32 +92,12 @@ void ipm_region_begin(struct region *reg)
       modules[i].regfunc(&(modules[i]), 1, reg);
     }
   }
-  
-#ifdef HAVE_PAPI
-  ipm_papi_read(ctr2);
-  for( i=0; i<MAXNUM_PAPI_EVENTS; i++ ) {
-    //reg->ctr_ipm[i] += (ctr2[i]-ctr1[i]);
-    reg->ctr_e[i]=ctr2[i];
-  }
-#endif
 }
 
 void ipm_region_end(struct region *reg)
 {
   int i;
 
-#ifdef HAVE_PAPI
-//  long long ctr1[MAXNUM_PAPI_EVENTS];
-  //  long long ctr2[MAXNUM_PAPI_EVENTS];
-#endif
-
-  /* fprintf(stderr, "region_end for reg=%x name='%s'\n", reg, reg->name);  
-   */
-
-#ifdef HAVE_PAPI
- // ipm_papi_read(ctr1);
-#endif
-  
   /* update data for region 'reg' */
   reg->wtime   += (ipm_wtime())  - (reg->wtime_e);
   reg->utime   += (ipm_utime())  - (reg->utime_e);
@@ -141,17 +109,6 @@ void ipm_region_end(struct region *reg)
       modules[i].regfunc(&(modules[i]), -1, reg);
     }
   }
-
-#ifdef HAVE_PAPI
-  // ipm_papi_read(ctr2);
-  /*
-  for( i=0; i<MAXNUM_PAPI_EVENTS; i++ ) {
-    //reg->ctr_ipm[i] += (ctr2[i]-ctr1[i]);
-    reg->ctr[i] += (ctr1[i]-reg->ctr_e[i]);
-  }
-    */
-#endif
-
 }
 
 
@@ -313,7 +270,7 @@ void* rsfunc_enum_l1_regions(region_t *reg, unsigned level, int flags, void *ptr
   return ptr;
 }
 
-/* tallen: never used
+// tallen: never used
 void* rsfunc_adjust_ctrs(region_t *reg, unsigned level, int flags, void *ptr) 
 {
   int i;
@@ -335,11 +292,10 @@ void* rsfunc_adjust_ctrs(region_t *reg, unsigned level, int flags, void *ptr)
   for( i=0; i<MAXNUM_PAPI_EVENTS; i++ ) {
     reg->ctr[i] -= reg->ctr_ipm[i];
   }
-#endif  HAVE_PAPI 
+#endif  
   
   return ptr;
 }
-*/
 
 void* rsfunc_find_by_id(region_t *reg, unsigned level, int flags, void *ptr) 
 {

--- a/src/report_xml.c
+++ b/src/report_xml.c
@@ -405,7 +405,7 @@ int xml_hpm(void *ptr, taskdata_t *t, region_t *reg) {
   //estimate time needed for good reading. papi_evtset[0] is always cpu core events
   // minimum samples to get a decent read * number of counters * counter swap
   // interval in seconds
-  char* time = reg->stime < SAMPLES * t->papi_evtset[0].nevts * (t->papi_mpx_interval.multiplex.ns / (1000000000.0)) ? "false" : "true";
+  char* time = reg->stime + reg->mtime < SAMPLES * t->papi_evtset[0].nevts * (t->papi_mpx_interval.multiplex.ns / (1000000000.0)) ? "false" : "true";
   nc=0;
   for( i=0; i<MAXNUM_PAPI_EVENTS; i++ ) {
     if( (t->papi_events[i].name[0]) )

--- a/src/report_xml.c
+++ b/src/report_xml.c
@@ -279,10 +279,10 @@ int xml_perf(void *ptr, taskdata_t *t) {
   /* retained the mtime entry here for backwards compatibility */
   res += ipm_printf(ptr, "<perf wtime=\"%.5e\" utime=\"%.5e\" "
 		    "stime=\"%.5e\" mtime=\"%.5e\" "
-		    "gflop=\"%.5e\" gbyte=\"%.5e\" >",
+		    "gflop=\"%.5e\" gbyte=\"%.5e\" omp_num_threads=\"%u\">",
 		    IPM_TIMEVAL(t->t_stop)-IPM_TIMEVAL(t->t_start), 
 		    t->utime, t->stime, t->mtime,
-		    gflops, procmem);
+		    gflops, procmem, t->num_threads);
   res += ipm_printf(ptr, "</perf>\n");
 
   return res;

--- a/src/report_xml.c
+++ b/src/report_xml.c
@@ -403,7 +403,7 @@ int xml_hpm(void *ptr, taskdata_t *t, region_t *reg) {
 #ifdef HAVE_PAPI
   double gflops=0.0;
   //regions shorter than one second for now
-  char* time = ipm_stime() < 1 ? "false" : "true";
+  char* time = reg->stime < 1.0 ? "false" : "true";
 
   nc=0;
   for( i=0; i<MAXNUM_PAPI_EVENTS; i++ ) {

--- a/src/report_xml.c
+++ b/src/report_xml.c
@@ -400,12 +400,10 @@ int xml_hpm(void *ptr, taskdata_t *t, region_t *reg) {
   int i, nc;
   int res=0;
 #ifdef HAVE_PAPI
-#define SAMPLES 5
   double gflops=0.0;
   //estimate time needed for good reading. papi_evtset[0] is always cpu core events
   // minimum samples to get a decent read * number of counters * counter swap
   // interval in seconds
-  char* time = reg->stime + reg->utime < SAMPLES * t->papi_evtset[0].nevts * (t->papi_mpx_interval.multiplex.ns / (1000000000.0)) ? "false" : "true";
   nc=0;
   for( i=0; i<MAXNUM_PAPI_EVENTS; i++ ) {
     if( (t->papi_events[i].name[0]) )
@@ -415,7 +413,7 @@ int xml_hpm(void *ptr, taskdata_t *t, region_t *reg) {
   // tyler: this only reports for rank == 0 regardless of task
   gflops = ipm_papi_gflops(reg->ctr, reg->wtime);
 
-  res += ipm_printf(ptr, "<hpm api=\"PAPI\" ncounter=\"%d\" eventset=\"0\" gflop=\"%.5e\" valid_region=\"%s\">\n",
+  res += ipm_printf(ptr, "<hpm api=\"PAPI\" ncounter=\"%d\" eventset=\"0\" gflop=\"%.5e\" >\n",
 		    nc, gflops, time);
   for( i=0; i<MAXNUM_PAPI_EVENTS; i++ ) {
     if( !(t->papi_events[i].name[0]) )
@@ -529,9 +527,9 @@ int xml_noregion(void *ptr, taskdata_t *t, region_t *reg, ipm_hent_t *htab) {
     mtime -= tmp->mtime;
 
 #ifdef HAVE_PAPI
-    for( i=0; i<MAXNUM_PAPI_EVENTS; i++ ) {
-      noregion.ctr[i] -= tmp->ctr[i];
-    }
+    //for( i=0; i<MAXNUM_PAPI_EVENTS; i++ ) {
+    //  noregion.ctr[i] -= tmp->ctr[i];
+    //}
 #endif
 #ifdef HAVE_PMON
 

--- a/src/report_xml.c
+++ b/src/report_xml.c
@@ -405,7 +405,7 @@ int xml_hpm(void *ptr, taskdata_t *t, region_t *reg) {
   //estimate time needed for good reading. papi_evtset[0] is always cpu core events
   // minimum samples to get a decent read * number of counters * counter swap
   // interval in seconds
-  char* time = reg->stime + reg->mtime < SAMPLES * t->papi_evtset[0].nevts * (t->papi_mpx_interval.multiplex.ns / (1000000000.0)) ? "false" : "true";
+  char* time = reg->stime + reg->utime < SAMPLES * t->papi_evtset[0].nevts * (t->papi_mpx_interval.multiplex.ns / (1000000000.0)) ? "false" : "true";
   nc=0;
   for( i=0; i<MAXNUM_PAPI_EVENTS; i++ ) {
     if( (t->papi_events[i].name[0]) )

--- a/src/report_xml.c
+++ b/src/report_xml.c
@@ -402,7 +402,8 @@ int xml_hpm(void *ptr, taskdata_t *t, region_t *reg) {
   int res=0;
 #ifdef HAVE_PAPI
   double gflops=0.0;
-
+  //regions shorter than one second for now
+  char* time = ipm_stime() < 1 ? "false" : "true";
 
   nc=0;
   for( i=0; i<MAXNUM_PAPI_EVENTS; i++ ) {
@@ -413,8 +414,8 @@ int xml_hpm(void *ptr, taskdata_t *t, region_t *reg) {
   // tyler: this only reports for rank == 0 regardless of task
   gflops = ipm_papi_gflops(reg->ctr, reg->wtime);
 
-  res += ipm_printf(ptr, "<hpm api=\"PAPI\" ncounter=\"%d\" eventset=\"0\" gflop=\"%.5e\">\n",
-		    nc, gflops);
+  res += ipm_printf(ptr, "<hpm api=\"PAPI\" ncounter=\"%d\" eventset=\"0\" gflop=\"%.5e\" valid_region=\"%s\">\n",
+		    nc, gflops, time);
   for( i=0; i<MAXNUM_PAPI_EVENTS; i++ ) {
     if( !(papi_events[i].name[0]) )
       continue;
@@ -567,10 +568,11 @@ int xml_region(void *ptr, taskdata_t *t, region_t *reg, ipm_hent_t *htab) {
 		    reg->wtime, reg->utime, reg->stime, 
 		    reg->mtime, reg->iotime, reg->omptime, reg->ompidletime);
   */
-
+  
+  
   res += ipm_printf(ptr, "<region label=\"%s\" nexits=\"%u\" "
 		    "wtime=\"%.5e\" utime=\"%.5e\" stime=\"%.5e\" "
-		    "mtime=\"%.5e\" id=\"%d\" >\n",
+		    "mtime=\"%.5e\" id=\"%d\">\n",
 		    reg->name, reg->nexecs, reg->wtime, 
 		    reg->utime, reg->stime, reg->mtime,
 		    internal2xml[reg->id]);

--- a/src/report_xml.c
+++ b/src/report_xml.c
@@ -427,12 +427,13 @@ int xml_hpm(void *ptr, taskdata_t *t, region_t *reg) {
 #ifdef HAVE_PMON
     if (task.flags & FLAG_PMON)
     {
-    res += ipm_printf(ptr,
-"<pmon\n\
-<device name=\"node\" avg_power=\"%lf\" energy=\"%lf\">\n\
-<device name=\"cpu\"  avg_power=\"%lf\" energy=\"%lf\">\n\
-<device name=\"memory\" avg_power=\"%lf\" energy=\"%lf\">\n\
-<device name=\"misc\" avg_power=\"%lf\" energy=\"%lf\">\n\
+        //ensure even internal tags have closing tags...
+        res += ipm_printf(ptr,
+"<pmon>\n\
+<device name=\"node\" avg_power=\"%lf\" energy=\"%lf\"></device>\n\
+<device name=\"cpu\"  avg_power=\"%lf\" energy=\"%lf\"></device>\n\
+<device name=\"memory\" avg_power=\"%lf\" energy=\"%lf\"></device>\n\
+<device name=\"misc\" avg_power=\"%lf\" energy=\"%lf\"></device>\n\
 </pmon>\n",
           reg->energy/reg->wtime, reg->energy,
           reg->cpu_energy/reg->wtime, reg->cpu_energy,


### PR DESCRIPTION
Fix for papi multiplexing. Additionally, some papi functionality was refactored into the papi module for better support. PAPI and MPI primary data structures moved into taskdata so that they can be transferred to rank == 0 during serial IO if necessary - this conforms to existing standard for modules. 

Also minor fixes for papi, pmon xml output to support existing perl analysis script and enhance the functionality of new python analysis scripts.