### PR TITLE
Remove LDFLAGS="" directive on configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -315,7 +315,6 @@ src/Makefile
 utils/Makefile
 ])
 
-LDFLAGS=""
 AC_CONFIG_FILES([
 test/Makefile
 test/test.allgather/Makefile


### PR DESCRIPTION
This directive effectively disabled any LDFLAGS generated during
configure phase, since it was always set to nothing: LDFLAGS=""

After the removal proper LDFLAGS are generated after bootstrap.sh